### PR TITLE
Update `src/task.json` to use Node 16 and increment version

### DIFF
--- a/src/task.json
+++ b/src/task.json
@@ -12,8 +12,8 @@
     ],
     "version": {
         "Major": "2",
-        "Minor": "5",
-        "Patch": "808"
+        "Minor": "6",
+        "Patch": "0"
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",
@@ -232,7 +232,7 @@
     ],
     "sourceDefinitions": [],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "WorkItemUpdater.js"
         }
     }


### PR DESCRIPTION
* Change `execution` section to use `Node16` instead of `Node10`
* Update `version` section to reflect new version (2.6.0)